### PR TITLE
[sickhub/cronjobs] Support setting timeZone

### DIFF
--- a/sickhub/cronjobs/Chart.yaml
+++ b/sickhub/cronjobs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cronjobs
 description: A generic helm cronjob chart for kubernetes
 type: application
-version: 0.1.6
+version: 0.1.7
 appVersion: latest
 home: https://github.com/SickHub
 icon: https://raw.githubusercontent.com/SickHub/charts/master/sickhub/cronjobs/icon.png

--- a/sickhub/cronjobs/templates/cronjob.yaml
+++ b/sickhub/cronjobs/templates/cronjob.yaml
@@ -31,6 +31,9 @@ spec:
   failedJobsHistoryLimit: {{ default 1 .failedJobsHistoryLimit }}
   successfulJobsHistoryLimit: {{ default 1 .successfulJobsHistoryLimit }}
   schedule: {{ .schedule | quote }}
+  {{- if and (gte .Capabilities.KubeVersion.Version "1.27.0") .timeZone }}
+    timeZone: {{ .timeZone }}
+  {{- end }}
   {{- if .suspend }}
   suspend: {{ .suspend }}
   {{- end }}

--- a/sickhub/cronjobs/values.yaml
+++ b/sickhub/cronjobs/values.yaml
@@ -56,6 +56,8 @@ env: []
 jobs: {}
 #  test:
 #    schedule: "*/5 * * * *"
+#    # see https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones
+#    timeZone: "Etc/UTC"
 #    command:
 #      - /bin/sh
 #      - -c


### PR DESCRIPTION
Closes #42 

Add the timezone option to the cronjob chart (supported in Kubernetes 1.27.0+)
https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones