### PR TITLE
[sickhub/cronjobs] Support release namespace override

### DIFF
--- a/sickhub/cronjobs/Chart.yaml
+++ b/sickhub/cronjobs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cronjobs
 description: A generic helm cronjob chart for kubernetes
 type: application
-version: 0.1.7
+version: 0.2.0
 appVersion: latest
 home: https://github.com/SickHub
 icon: https://raw.githubusercontent.com/SickHub/charts/master/sickhub/cronjobs/icon.png

--- a/sickhub/cronjobs/templates/_helpers.tpl
+++ b/sickhub/cronjobs/templates/_helpers.tpl
@@ -60,3 +60,10 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Namespace to be released into
+*/}}
+{{- define "cronjobs.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride }}
+{{- end }}

--- a/sickhub/cronjobs/templates/configmap.yaml
+++ b/sickhub/cronjobs/templates/configmap.yaml
@@ -1,5 +1,6 @@
 {{- $chart_name := include "cronjobs.fullname" . }}
 {{- $chart_labels := include "cronjobs.labels" . }}
+{{- $namespace := include "cronjobs.namespace" . }}
 
 {{- if .Values.configMaps }}
 {{- range $name, $map := .Values.configMaps }}
@@ -9,6 +10,7 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   name: {{ $chart_name }}-{{ $name }}
+  namespace: {{ $namespace }}
   labels:
     {{- $chart_labels | nindent 4 }}
   annotations:

--- a/sickhub/cronjobs/templates/cronjob.yaml
+++ b/sickhub/cronjobs/templates/cronjob.yaml
@@ -3,6 +3,7 @@
 {{- $chart_labels := include "cronjobs.labels" . }}
 {{- $chart_selector_labels := include "cronjobs.selectorLabels" . }}
 {{- $service_account_name := include "cronjobs.serviceAccountName" . }}
+{{- $namespace := include "cronjobs.namespace" . }}
 {{- $registry := .Values.image.registry }}
 {{- $tag := .Values.image.tag | default .Chart.AppVersion }}
 {{- $image_pull_secrets := .Values.imagePullSecrets }}
@@ -22,6 +23,7 @@ apiVersion: {{ $api_version }}
 kind: CronJob
 metadata:
   name: {{ $chart_name }}-{{ $name }}
+  namespace: {{ $namespace }}
   labels:
     {{- $chart_labels | nindent 4 }}
   annotations:

--- a/sickhub/cronjobs/templates/secrets.yaml
+++ b/sickhub/cronjobs/templates/secrets.yaml
@@ -1,5 +1,6 @@
 {{- $chart_name := include "cronjobs.fullname" . }}
 {{- $chart_labels := include "cronjobs.labels" . }}
+{{- $namespace := include "cronjobs.namespace" . }}
 
 {{- if .Values.dockerConfigJson }}
 ---
@@ -7,6 +8,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $chart_name }}-registry
+  namespace: {{ $namespace }}
   labels:
     {{- $chart_labels | nindent 4 }}
   annotations:
@@ -22,6 +24,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $chart_name }}-{{ $name }}
+  namespace: {{ $namespace }}
   labels:
     {{- $chart_labels | nindent 4 }}
   annotations:

--- a/sickhub/cronjobs/templates/serviceaccount.yaml
+++ b/sickhub/cronjobs/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "cronjobs.serviceAccountName" . }}
+  namespace: {{ include "cronjobs.namespace" . }}
   labels:
     {{- include "cronjobs.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/sickhub/cronjobs/values.yaml
+++ b/sickhub/cronjobs/values.yaml
@@ -1,5 +1,6 @@
 nameOverride: ""
 fullnameOverride: ""
+namespaceOverride: ""
 
 image:
   registry: docker.io


### PR DESCRIPTION
Closes #58 

Support release namespace override.
https://helm.sh/docs/chart_template_guide/builtin_objects/
https://kubernetes.io/docs/tasks/administer-cluster/namespaces-walkthrough/